### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -11,7 +11,7 @@
 #######################################
 sleep	KEYWORD2
 deepSleep	KEYWORD2
-idle    KEYWORD2
+idle	KEYWORD2
 doze	KEYWORD2
 wakeFromDoze	KEYWORD2
 


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords